### PR TITLE
Add required quotes to ignore-globs example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also specify a number of options to the action.
         should-scan-archives: false
         output-filename: devskim-results.sarif
         output-directory: path/to/output (appended to $GITHUB_WORKSPACE)
-        ignore-globs: **/.git/**,*.txt
+        ignore-globs: "**/.git/**,*.txt"
 ```
 
 ## Features


### PR DESCRIPTION
See this example https://github.com/microsoft/DevSkim-Action/blob/430c605a9149e1c8f2d5ced90ec469e6ccdd858e/action.yml#L23

Without this, the sample code will fail.