### PR TITLE
Update entrypoint.sh to support DevSkim 0.8 argument style

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 $devSkimVersion = /tools/devskim --version
 echo "Running Devskim $devSkimVersion"
-if (echo "$devSkimVersion" | tail -n 1 | grep '^0\.[6-7]\.[0-9][0-9]*') # Pre 0.8
+if [(echo "$devSkimVersion" | tail -n 1 | grep '^0\.[6-7]\.[0-9][0-9]*')]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 
     /tools/devskim analyze --source-code "$ScanTarget" --output-file "$OutputDirectory/$3" $Opts --ignore-globs $5 --base-path $GITHUB_WORKSPACE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,9 +22,10 @@ if [ "$2" = "true" ]; then
     Opts = "-c"
 fi
 
-$devSkimVersion = /tools/devskim --version
-echo "Running Devskim $devSkimVersion"
-if [(echo "$devSkimVersion" | tail -n 1 | grep '^0\.[6-7]\.[0-9][0-9]*')]; then # Pre 0.8
+/tools/devskim --version
+
+$devSkimVersion = /tools/devskim --version | tail -n 1
+if [[ $devSkimVersion =~ '^0\.[6-7]\.[0-9][0-9]*']]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 
     /tools/devskim analyze --source-code "$ScanTarget" --output-file "$OutputDirectory/$3" $Opts --ignore-globs $5 --base-path $GITHUB_WORKSPACE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 /tools/devskim --version
 
-devSkimVersion = $(/tools/devskim --version | tail -n 1)
+let devSkimVersion=$(/tools/devskim --version | tail -n 1)
 if [[ $devSkimVersion =~ ^0\.[6-7]\.[0-9][0-9]* ]]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,10 @@ if [ "$2" = "true" ]; then
     Opts = "-c"
 fi
 
-/tools/devskim --version
-
-/tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
+$devSkimVersion = /tools/devskim --version
+echo "Running Devskim $devSkimVersion"
+if (echo "$devSkimVersion" | tail -n 1 | grep '^0\.[6-7]\.[0-9][0-9]*') # Pre 0.8
+    /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
+else # Post 0.8 
+    /tools/devskim analyze --source-code "$ScanTarget" --output-file "$OutputDirectory/$3" $Opts --ignore-globs $5 --base-path $GITHUB_WORKSPACE
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 /tools/devskim --version
 
 devSkimVersion = $(/tools/devskim --version | tail -n 1)
-if [[ $devSkimVersion =~ '^0\.[6-7]\.[0-9][0-9]*']]; then # Pre 0.8
+if [[ $devSkimVersion =~ ^0\.[6-7]\.[0-9][0-9]* ]]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 
     /tools/devskim analyze --source-code "$ScanTarget" --output-file "$OutputDirectory/$3" $Opts --ignore-globs $5 --base-path $GITHUB_WORKSPACE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 /tools/devskim --version
 
-devSkimVersion = (/tools/devskim --version | tail -n 1)
+devSkimVersion = $(/tools/devskim --version | tail -n 1)
 if [[ $devSkimVersion =~ '^0\.[6-7]\.[0-9][0-9]*']]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 /tools/devskim --version
 
-let devSkimVersion=$(/tools/devskim --version | tail -n 1)
+let devSkimVersion="$(/tools/devskim --version | tail -n 1)"
 if [[ $devSkimVersion =~ ^0\.[6-7]\.[0-9][0-9]* ]]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 /tools/devskim --version
 
-let devSkimVersion="$(/tools/devskim --version | tail -n 1)"
+devSkimVersion="$(/tools/devskim --version | tail -n 1)"
 if [[ $devSkimVersion =~ ^0\.[6-7]\.[0-9][0-9]* ]]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 /tools/devskim --version
 
-$devSkimVersion = /tools/devskim --version | tail -n 1
+devSkimVersion = (/tools/devskim --version | tail -n 1)
 if [[ $devSkimVersion =~ '^0\.[6-7]\.[0-9][0-9]*']]; then # Pre 0.8
     /tools/devskim analyze "$ScanTarget" "$OutputDirectory/$3" -f sarif $Opts -g $5 --base-path $GITHUB_WORKSPACE
 else # Post 0.8 


### PR DESCRIPTION
Update entrypoint to include newer argument style. The entrypoint script should now check if it is on devskim 0.7 or earlier and use the old style, or for newer versions use the new format. This is a temporary change to smooth over the transition to the behavior currently in main. Once that has been released as final, we can remove the check here as it will no longer be hit.