### PR TITLE
Bump upload-artifact to 3.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Self test action
       uses: ./
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3.1.0
+      uses: actions/upload-artifact@v3.1.2
       with:
         # Artifact name
         name: devskim-results.sarif # optional, default is artifact


### PR DESCRIPTION
upload-artifact 3.1.0 is over a year old, changes compared to the latest version are minor so I see no issue in updating it

https://github.com/actions/upload-artifact/compare/v3.1.0...v3.1.2