### PR TITLE
Adds options-json argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can also specify a number of options to the action.
         output-directory: path/to/output (appended to $GITHUB_WORKSPACE)
         ignore-globs: "**/.git/**,*.txt"
         exclude-rules: DS176209, DS148264
+        options-json: path/to/options.json
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can also specify a number of options to the action.
         output-filename: devskim-results.sarif
         output-directory: path/to/output (appended to $GITHUB_WORKSPACE)
         ignore-globs: "**/.git/**,*.txt"
-        exclude-rules: DS176209, DS148264
+        exclude-rules: DS176209,DS148264
         options-json: path/to/options.json
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Optional comma separated list of rule IDs to ignore'
     required: false
     default: ""
+  options-json:
+    description: 'Optional path in the repository containing a json to provide to the --options-json argument'
+    required: false
+    default: ""
 branding:
   icon: 'check-square'  
   color: 'green'  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@
 # $4 is the output directory
 # $5 is the file globs to ignore
 # $6 is the ruleids to exclude
+# $7 is the path to a json file for the --options-json argument
 
 if [ "$1" = "GITHUB_WORKSPACE" ]; then
     ScanTarget=$GITHUB_WORKSPACE
@@ -17,6 +18,12 @@ if [ "$4" = "GITHUB_WORKSPACE" ]; then
     OutputDirectory=$GITHUB_WORKSPACE
 else
     OutputDirectory=$GITHUB_WORKSPACE/$4
+fi
+
+if [ -z "$7"]; then
+    OptionsJsonArg=""
+else
+    OptionsJsonArg="--options-json $GITHUB_WORKSPACE/$7"
 fi
 
 if [ "$2" = "true" ]; then


### PR DESCRIPTION
Adds the `options-json` argument to the Action to allow specifying any of DevSkim's options. See https://github.com/microsoft/DevSkim/wiki/Analyze-Command#configure-devskim-with-a-json-file.

Supersedes #20.