### PR TITLE
Update Github actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       security-events: write
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Check that dockerfile can be built
     - name: Build action image
@@ -35,7 +35,7 @@ jobs:
     - name: Self test action
       uses: ./
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: devskim-results.sarif # optional, default is artifact

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The DevSkim GitHub Action outputs a sarif file compatible with GitHub's Security
 Add DevSkim to your GitHub Actions pipeline like below.
 
 ```
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: microsoft/DevSkim-Action@v1
     - uses: github/codeql-action/upload-sarif@v2
       with:


### PR DESCRIPTION
  - update checkout to v4 (Node 16 to 20)
  - Pin upload-artifact only to major version so it doesn't need to be updated each time for every minor release