### PR TITLE
Bump upload-sarif to @v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Self test action
       uses: ./
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: devskim-results.sarif # optional, default is artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,6 @@ jobs:
         command: validate devskim-results.sarif # optional, default is version
     # Make sure results exist and can by uploaded
     - name: Upload results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: devskim-results.sarif


### PR DESCRIPTION
As per: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

> Exactly what do I need to change?
> To upgrade to CodeQL Action v3, open your CodeQL workflow file(s) in the .github directory of your repository and look for references to:
> 
> github/codeql-action/init@v2
> github/codeql-action/autobuild@v2
> github/codeql-action/analyze@v2
> github/codeql-action/upload-sarif@v2
> 
> These entries need to be replaced with their v3 equivalents:
> 
> github/codeql-action/init@v3
> github/codeql-action/autobuild@v3
> github/codeql-action/analyze@v3
> github/codeql-action/upload-sarif@v3