### PR TITLE
Fix archive crawling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
     branches: [ 'main' ]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   # Check that container image can be built

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ else
 fi
 
 if [ "$2" = "true" ]; then
-    Opts = "-c"
+    Opts="-c"
 fi
 
 if [ -z "$6" ]; then


### PR DESCRIPTION
POSIX shells like `bash` expect no space between the name of the variable being assigned and the `=` operator.

# Steps to reproduce

The easiest way to reproduce the issue is build/run the Docker image locally.

First build the image:

```text
$ docker build . -t devskim
```

Then run it with second argument set to `true` and notice the error message from `bash`:

``` text
$ docker run --rm devskim . true 
/entrypoint.sh: line 31: Opts: command not found
devskim 1.0.52+74513a99d4
© Microsoft Corporation. All rights reserved.
...
```
