### PR TITLE
Fix CodeQL version in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add DevSkim to your GitHub Actions pipeline like below.
 ```
     - uses: actions/checkout@v4
     - uses: microsoft/DevSkim-Action@v1
-    - uses: github/codeql-action/upload-sarif@v2
+    - uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: devskim-results.sarif
 ```


### PR DESCRIPTION
Hello!
I hope you are doing well!

I'm sending this PR just to fix the CodeQL version in the README Usage example section.

The example is using the second version, but this version deprecated.

![image](https://github.com/user-attachments/assets/3bc3d919-b6ce-425c-81e3-fbc014ece83c)

:)
